### PR TITLE
Add nodejs as a new runtime name

### DIFF
--- a/src/Nacmartin/PhpExecJs/PhpExecJs.php
+++ b/src/Nacmartin/PhpExecJs/PhpExecJs.php
@@ -60,7 +60,7 @@ class PhpExecJs
 
     /**
      * Calls a JavaScript function against an array of arguments.
-     *    
+     * 
      * @param string $function
      * @param array  $arguments
      *

--- a/src/Nacmartin/PhpExecJs/PhpExecJs.php
+++ b/src/Nacmartin/PhpExecJs/PhpExecJs.php
@@ -60,7 +60,7 @@ class PhpExecJs
 
     /**
      * Calls a JavaScript function against an array of arguments.
-     * 
+     *    
      * @param string $function
      * @param array  $arguments
      *

--- a/src/Nacmartin/PhpExecJs/PhpExecJs.php
+++ b/src/Nacmartin/PhpExecJs/PhpExecJs.php
@@ -60,7 +60,7 @@ class PhpExecJs
 
     /**
      * Calls a JavaScript function against an array of arguments.
-     * 
+     *  
      * @param string $function
      * @param array  $arguments
      *

--- a/src/Nacmartin/PhpExecJs/Runtime/ExternalRuntime.php
+++ b/src/Nacmartin/PhpExecJs/Runtime/ExternalRuntime.php
@@ -38,7 +38,7 @@ class ExternalRuntime implements RuntimeInterface
     /**
      * NodeJs binary.
      * 
-     * @var string
+     * @var array
      */
     private $binary;
 
@@ -46,10 +46,10 @@ class ExternalRuntime implements RuntimeInterface
      * Constructor.
      * 
      * @param string|null $name   the name of runtime
-     * @param string|null $binary the name of the binary command (ex. node)
+     * @param array|array() $binary the name of the binary command (ex. node)
      * @param array|null  $env    The environment variables or null to use the same environment as the current PHP process
      */
-    public function __construct($name, $binary = null, $env = null)
+    public function __construct($name, $binary = array(), $env = null)
     {
         $this->name = $name;
         $this->env = $env;
@@ -224,13 +224,18 @@ JS;
         $pathStr = getenv('PATH');
         $paths = explode(PATH_SEPARATOR, $pathStr);
         foreach ($paths as $path) {
-            $binaryPath = $path.DIRECTORY_SEPARATOR.$this->binary;
-            if (is_executable($path.DIRECTORY_SEPARATOR.$this->binary)) {
-                return $binaryPath;
+            foreach ($this->binary as $binary) {
+                $binaryPath = $path.DIRECTORY_SEPARATOR.$binary;
+                if (is_executable($path.DIRECTORY_SEPARATOR.$binary)) {
+                    return $binaryPath;
+                }
             }
         }
-        if ($wichBinaryPath = exec('which '.$this->binary)) {
-            return $wichBinaryPath;
+        
+        foreach ($this->binary as $binary) {
+            if ($wichBinaryPath = exec('which '.$binary)) {
+                return $wichBinaryPath;
+            }
         }
 
         return;

--- a/src/Nacmartin/PhpExecJs/Runtime/ExternalRuntime.php
+++ b/src/Nacmartin/PhpExecJs/Runtime/ExternalRuntime.php
@@ -23,28 +23,28 @@ class ExternalRuntime implements RuntimeInterface
 
     /**
      * env.
-     * 
+     *
      * @var array|null The environment variables or null to use the same environment as the current PHP process
      */
     public $env = null;
 
     /**
      * Timeout for the eval.
-     * 
+     *
      * @var bool
      */
     public $timeout = false;
 
     /**
      * NodeJs binary.
-     * 
+     *
      * @var array
      */
     private $binary;
 
     /**
      * Constructor.
-     * 
+     *
      * @param string|null $name   the name of runtime
      * @param array|array() $binary the name of the binary command (ex. node)
      * @param array|null  $env    The environment variables or null to use the same environment as the current PHP process
@@ -111,7 +111,7 @@ class ExternalRuntime implements RuntimeInterface
 
     /**
      * Embeds the code to eval in an environment that provides status of the result.
-     * 
+     *
      * @param string $code
      */
     public function embedInRuntime($code)
@@ -231,7 +231,7 @@ JS;
                 }
             }
         }
-        
+
         foreach ($this->binary as $binary) {
             if ($wichBinaryPath = exec('which '.$binary)) {
                 return $wichBinaryPath;

--- a/src/Nacmartin/PhpExecJs/Runtime/ExternalRuntime.php
+++ b/src/Nacmartin/PhpExecJs/Runtime/ExternalRuntime.php
@@ -23,28 +23,28 @@ class ExternalRuntime implements RuntimeInterface
 
     /**
      * env.
-     *
+     * 
      * @var array|null The environment variables or null to use the same environment as the current PHP process
      */
     public $env = null;
 
     /**
      * Timeout for the eval.
-     *
+     * 
      * @var bool
      */
     public $timeout = false;
 
     /**
      * NodeJs binary.
-     *
+     * 
      * @var array
      */
     private $binary;
 
     /**
      * Constructor.
-     *
+     * 
      * @param string|null $name   the name of runtime
      * @param array|array() $binary the name of the binary command (ex. node)
      * @param array|null $env    The environment variables or null to use the same environment as the current PHP process
@@ -111,7 +111,7 @@ class ExternalRuntime implements RuntimeInterface
 
     /**
      * Embeds the code to eval in an environment that provides status of the result.
-     *
+     * 
      * @param string $code
      */
     public function embedInRuntime($code)

--- a/src/Nacmartin/PhpExecJs/Runtime/ExternalRuntime.php
+++ b/src/Nacmartin/PhpExecJs/Runtime/ExternalRuntime.php
@@ -47,7 +47,7 @@ class ExternalRuntime implements RuntimeInterface
      *
      * @param string|null $name   the name of runtime
      * @param array|array() $binary the name of the binary command (ex. node)
-     * @param array|null  $env    The environment variables or null to use the same environment as the current PHP process
+     * @param array|null $env    The environment variables or null to use the same environment as the current PHP process
      */
     public function __construct($name, $binary = array(), $env = null)
     {

--- a/src/Nacmartin/PhpExecJs/Runtime/RuntimeInterface.php
+++ b/src/Nacmartin/PhpExecJs/Runtime/RuntimeInterface.php
@@ -14,7 +14,7 @@ interface RuntimeInterface
 
     /**
      * Calls a JavaScript function against an array of arguments.
-     * 
+     *
      * @param string $function
      * @param array  $arguments
      *
@@ -24,7 +24,7 @@ interface RuntimeInterface
 
     /**
      * Checks if the runtime is available.
-     * 
+     *
      * @return bool
      */
     public function isAvailable();

--- a/src/Nacmartin/PhpExecJs/Runtime/RuntimeInterface.php
+++ b/src/Nacmartin/PhpExecJs/Runtime/RuntimeInterface.php
@@ -31,7 +31,7 @@ interface RuntimeInterface
 
     /**
      * Returns the name of the runtime.
-     * 
+     *
      * @return string
      */
     public function getName();

--- a/src/Nacmartin/PhpExecJs/Runtime/RuntimeInterface.php
+++ b/src/Nacmartin/PhpExecJs/Runtime/RuntimeInterface.php
@@ -14,7 +14,7 @@ interface RuntimeInterface
 
     /**
      * Calls a JavaScript function against an array of arguments.
-     *
+     * 
      * @param string $function
      * @param array  $arguments
      *
@@ -24,14 +24,14 @@ interface RuntimeInterface
 
     /**
      * Checks if the runtime is available.
-     *
+     * 
      * @return bool
      */
     public function isAvailable();
 
     /**
      * Returns the name of the runtime.
-     *
+     * 
      * @return string
      */
     public function getName();

--- a/src/Nacmartin/PhpExecJs/RuntimeAutodetector.php
+++ b/src/Nacmartin/PhpExecJs/RuntimeAutodetector.php
@@ -14,8 +14,7 @@ class RuntimeAutodetector
         // Runners will be checked for availabilty by order in array so order
         // matters
         $this->runtimes[] = new V8jsRuntime('V8js PHP Extension (V8)');
-        $this->runtimes[] = new ExternalRuntime('Node.js (V8)', 'node');
-        $this->runtimes[] = new ExternalRuntime('Node.js (V8)', 'nodejs');
+        $this->runtimes[] = new ExternalRuntime('Node.js (V8)', ['node', 'nodejs']);
     }
 
     public function autodetect()

--- a/src/Nacmartin/PhpExecJs/RuntimeAutodetector.php
+++ b/src/Nacmartin/PhpExecJs/RuntimeAutodetector.php
@@ -14,7 +14,7 @@ class RuntimeAutodetector
         // Runners will be checked for availabilty by order in array so order
         // matters
         $this->runtimes[] = new V8jsRuntime('V8js PHP Extension (V8)');
-        $this->runtimes[] = new ExternalRuntime('Node.js (V8)', ['node', 'nodejs']);
+        $this->runtimes[] = new ExternalRuntime('Node.js (V8)', array('node', 'nodejs'));
     }
 
     public function autodetect()

--- a/src/Nacmartin/PhpExecJs/RuntimeAutodetector.php
+++ b/src/Nacmartin/PhpExecJs/RuntimeAutodetector.php
@@ -15,6 +15,7 @@ class RuntimeAutodetector
         // matters
         $this->runtimes[] = new V8jsRuntime('V8js PHP Extension (V8)');
         $this->runtimes[] = new ExternalRuntime('Node.js (V8)', 'node');
+        $this->runtimes[] = new ExternalRuntime('Node.js (V8)', 'nodejs');
     }
 
     public function autodetect()


### PR DESCRIPTION
On Debian, node js executable is called nodejs, so I suggest adding nodejs as a new runtime name.