### PR TITLE
Symfony/Process: Fix constructor deprecation warning for v4.2+

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -8,25 +8,25 @@
     "packages": [
         {
             "name": "symfony/process",
-            "version": "v3.0.2",
+            "version": "v4.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "dfecef47506179db2501430e732adbf3793099c8"
+                "reference": "e89969c00d762349f078db1128506f7f3dcc0d4a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/dfecef47506179db2501430e732adbf3793099c8",
-                "reference": "dfecef47506179db2501430e732adbf3793099c8",
+                "url": "https://api.github.com/repos/symfony/process/zipball/e89969c00d762349f078db1128506f7f3dcc0d4a",
+                "reference": "e89969c00d762349f078db1128506f7f3dcc0d4a",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5.9"
+                "php": "^7.1.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -53,7 +53,7 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2016-02-02T13:44:19+00:00"
+            "time": "2019-08-26T08:26:39+00:00"
         }
     ],
     "packages-dev": [

--- a/src/Nacmartin/PhpExecJs/Runtime/ExternalRuntime.php
+++ b/src/Nacmartin/PhpExecJs/Runtime/ExternalRuntime.php
@@ -302,7 +302,14 @@ JS;
      */
     protected function executeCommand($command)
     {
-        $process = new Process($command, null, $this->env);
+        if (method_exists('Symfony\Component\Process\Process', 'fromShellCommandLine')) {
+            // Symfony 4.2+
+            $process = Process::fromShellCommandline($command, null, $this->env);
+        } else {
+            // Older versions
+            $process = new Process($command, null, $this->env);
+        }
+
         if (false !== $this->timeout) {
             $process->setTimeout($this->timeout);
         }


### PR DESCRIPTION
This PR fixes the following warning, which is raised when `Symfony\Process` v4.2+ is used:

> Passing a command as string when creating a "Symfony\Component\Process\Process" instance is deprecated since Symfony 4.2, pass it as an array of its arguments instead, or use the "Process::fromShellCommandline()" constructor if you need features provided by the shell.

This PR changes `executeCommand` behavior to detect and use `fromShellCommandline()` if available.